### PR TITLE
Merge template from JupyterLab in org templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,11 +2,12 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us repair something that is currently broken
 labels: bug
-
 ---
-<!-- Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->
 
-<!-- Before creating a new issue:
+<!-- Welcome! Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
+<!--
+Before creating a new issue:
 * Search for relevant issues
 * Follow the issue reporting guidelines:
 https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
@@ -36,9 +37,9 @@ https://jupyterlab.readthedocs.io/en/latest/getting_started/issue.html
 
 <!--Complete the following for context, and add any other relevant context-->
 
-- Operating System and version:
-- Browser and version:
-- JupyterLab version:
+- Operating System and version: <!-- e.g. Linux Ubuntu 19.06 -->
+- Browser and version: <!-- e.g. Chrome 86 -->
+- JupyterLab version: <!-- e.g. 3.0.16 -->
 
 <details><summary>Troubleshoot Output</summary>
 <pre>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,8 @@
+blank_issues_enabled: false
 contact_links:
   - name: "\U0001F914 All other questions, including if you're not sure what to do."
     url: https://discourse.jupyter.org
     about: Search on Discourse for similar questions or ask for help there.
+  - name: \U+1F4AC Chat with devs
+    url: https://gitter.im/jupyterlab/jupyterlab
+    about: Ask short questions about using JupyterLab

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature Request
+name: \U0001F680 Feature Request
 about: Suggest a new feature or a change
 labels: enhancement
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,11 +1,14 @@
 ---
-name: "\U0001F680 Feature request"
-about: Suggest a new feature or a big change
+name: Feature Request
+about: Suggest a new feature or a change
 labels: enhancement
-
 ---
+
+<!-- Welcome! Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->
+
 <!--
-Welcome! Thanks for thinking of a way to improve JupyterLab. If this solves a problem for you, then it probably solves that problem for lots of people! So the whole community will benefit from this request.
+Thanks for thinking of a way to improve JupyterLab. If this solves a problem for you, then it probably solves that problem for lots of people! So the whole community will benefit from this request.
+
 
 Before creating a new feature request please search the issues for relevant feature requests.
 -->
@@ -30,3 +33,4 @@ Before creating a new feature request please search the issues for relevant feat
 <!-- Add any other context or screenshots about the feature request here. You can also include links to examples of other programs that have something similar to your request. For example:
 
 * Another project [...] solved this by [...]
+-->


### PR DESCRIPTION
This moves the jupyterlab template at the organization level (so that entries to redirect users to Gitter and Discourse shows up when opening a new issue)