### PR TITLE
Add "status:Needs Triage" label to new bugs and enhancements in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug report"
 about: Create a report to help us repair something that is currently broken
-labels: bug
+labels: bug, status:Needs Triage
 ---
 
 <!-- Welcome! Thank you for contributing. These HTML comments will not render in the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F680 Feature Request"
 about: Suggest a new feature or a change
-labels: enhancement
+labels: enhancement, status:Needs Triage
 ---
 
 <!-- Welcome! Thank you for contributing. These HTML comments will not render in the issue, but you can delete them once you've read them if you prefer! -->


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyterlab/pull/11661.

Adds the "status:Needs Triage" label to new bugs and enhancements in Jupyter projects. This allows maintainers to perform triage against new bugs and issues regularly.