### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,2 +1,1 @@
-github: numfocus
-custom: https://numfocus.org/donate-to-jupyter
+custom: https://jupyter.org/about#donate


### PR DESCRIPTION
As per https://github.com/jupyter/governance/issues/204#issuecomment-2489829366 the preferred link is now https://jupyter.org/about#donate since Jupyter is no longer under numfocus