### PR TITLE
Link to Zulip instead of Gitter

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discourse.jupyter.org
     about: Search on Discourse for similar questions or ask for help there.
   - name: "\U0001F4AC Chat with the devs"
-    url: https://gitter.im/jupyterlab/jupyterlab
+    url: https://jupyter.zulipchat.com
     about: Ask short questions about using JupyterLab


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/frontends-team-compass/issues/263

This entry was otherwise redirecting folks to the Gitter room:

![image](https://github.com/user-attachments/assets/03c781f2-4ad2-4eb9-b1d6-25ae5b755e65)
