### PR TITLE
Add workflow for updating the PR triage board

### DIFF
--- a/.github/workflows/pr-triage-board.yml
+++ b/.github/workflows/pr-triage-board.yml
@@ -1,0 +1,19 @@
+name: Update PR Triage Board
+
+on:
+  schedule:
+    - cron: '13 * * * *'  # Every hour
+  workflow_dispatch:  # Allows triggering manually from the UI
+
+jobs:
+  update-pr-triage-board:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run PR Triage Bot
+        uses: yuvipanda/pr-triage-board-bot@main
+        with:
+          organization: 'jupyterlab'
+          project-number: '11'
+          gh-app-id: '1842581'
+          gh-app-installation-id: '82755492'
+          gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
See https://github.com/orgs/jupyterlab/projects/11 for the board we are updating

This should work better than https://github.com/jupyterlab/frontends-team-compass/pull/282, now that the pr triage board exposes a composite action rather than a reusable workflow.